### PR TITLE
AppImage fixes

### DIFF
--- a/src/tbc_video_export/common/file_helper.py
+++ b/src/tbc_video_export/common/file_helper.py
@@ -271,8 +271,8 @@ class FileHelper:
         return files.find_binary(str(tool_name))
 
     def _get_tbc_tool_path(self, tool_name: ProcessName) -> Path | list[Path | str]:
-        if self._opts.appimage:
+        if self._opts.tbc_tools_appimage:
             # return list with appimage file and tool name
-            return [files.find_binary(self._opts.appimage), str(tool_name)]
+            return [files.find_binary(self._opts.tbc_tools_appimage), str(tool_name)]
 
         return self._get_tool_path(tool_name)

--- a/src/tbc_video_export/opts/opts.py
+++ b/src/tbc_video_export/opts/opts.py
@@ -26,7 +26,7 @@ class Opts(argparse.Namespace):
     input_file: str
     output_file: str | None
     threads: int
-    appimage: str
+    tbc_tools_appimage: str
     two_step: bool
     async_nt_pipes: bool
     video_system: VideoSystem | None

--- a/src/tbc_video_export/opts/opts_parser.py
+++ b/src/tbc_video_export/opts/opts_parser.py
@@ -90,10 +90,10 @@ def parse_opts(
     )
 
     general_opts.add_argument(
-        "--appimage",
+        "--tbc-tools-appimage",
         type=str,
         metavar="appimage file",
-        help="Run the tools from an AppImage file.\n\n",
+        help="Run the tbc-tools from an AppImage file.\n\n",
     )
 
     general_opts.add_argument(

--- a/src/tbc_video_export/process/wrapper/wrapper.py
+++ b/src/tbc_video_export/process/wrapper/wrapper.py
@@ -37,7 +37,7 @@ class Wrapper(ABC):
     @property
     def binary(self) -> FlatList:
         """Return wrapped binary name."""
-        return FlatList(self._state.file_helper.get_tool(self.process_name))
+        return FlatList(self._state.file_helper.tools[self.process_name])
 
     @cached_property
     def tbc_type(self) -> TBCType:

--- a/tests/test_file_helper.py
+++ b/tests/test_file_helper.py
@@ -184,13 +184,19 @@ class TestTBCJson:
         )
         helper = FileHelper(state.opts, state.config)
 
-        assert helper.get_tool(proc) == Path(str(proc))
+        assert helper.tools[proc] == Path(str(proc))
 
-    @pytest.mark.parametrize("proc", procs)
+    appimage_tbc_tools_procs = [
+        ProcessName.LD_CHROMA_DECODER,
+        ProcessName.LD_DROPOUT_CORRECT,
+        ProcessName.LD_EXPORT_METADATA,
+        ProcessName.LD_PROCESS_EFM,
+        ProcessName.LD_PROCESS_VBI,
+    ]
+
     def test_tools_appimage(  # noqa: D102
         self,
         program_state: Callable[[list[str], Path], ProgramState],
-        proc: ProcessName,
     ) -> None:
         with NamedTemporaryFile() as file:
             state = program_state(
@@ -205,10 +211,12 @@ class TestTBCJson:
             )
             helper = FileHelper(state.opts, state.config)
 
-            assert helper.get_tool(proc) == [
-                Path(file.name),
-                str(proc),
-            ]
+            # ensure appimage only used for tbc-tools
+            for k, v in helper.tools.items():
+                if k in self.appimage_tbc_tools_procs:
+                    assert v == [Path(file.name), str(k)]
+                else:
+                    assert v == Path(str(k))
 
     def test_out_file_dir(  # noqa: D102
         self,

--- a/tests/test_file_helper.py
+++ b/tests/test_file_helper.py
@@ -204,7 +204,7 @@ class TestTBCJson:
                     "--process-efm",
                     "--process-vbi",
                     "--export-metadata",
-                    "--appimage",
+                    "--tbc-tools-appimage",
                     file.name,
                 ],
                 Path("tests/files/pal_svideo.tbc"),


### PR DESCRIPTION
- Rename `--appimage` to `--tbc-tools-appimage`. When the AppImage build used `--appimage` it would be passed to the wrapper and throw an error (#75).

- Only tbc-tools should use the AppImage. It was previously also trying to run `FFmpeg` and would fail.