### PR TITLE
Add --dropout-allow-interfield option

### DIFF
--- a/src/tbc_video_export/opts/opts.py
+++ b/src/tbc_video_export/opts/opts.py
@@ -76,6 +76,7 @@ class Opts(argparse.Namespace):
     # dropout-correct
     no_dropout_correct: bool
     dropout_correct_threads: int | None
+    dropout_allow_interfield: bool
 
     # luma
     luma_only: bool

--- a/src/tbc_video_export/opts/opts_ldtools.py
+++ b/src/tbc_video_export/opts/opts_ldtools.py
@@ -312,6 +312,18 @@ def add_ldtool_opts(parent: argparse.ArgumentParser) -> None:
         ),
     )
 
+    dropout_correct_opts.add_argument(
+        "--dropout-allow-interfield",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow interfield dropout correction. (default: no)\n"
+            "  - This will run ld-dropout-correct without the --intra flag."
+            "\n\n"
+        ),
+    )
+
+
     # process-vbi
     process_vbi = parent.add_argument_group("process vbi")
     process_vbi.add_argument(

--- a/src/tbc_video_export/process/wrapper/wrapper_ld_dropout_correct.py
+++ b/src/tbc_video_export/process/wrapper/wrapper_ld_dropout_correct.py
@@ -27,11 +27,10 @@ class WrapperLDDropoutCorrect(Wrapper):
 
     @property
     def command(self) -> FlatList:  # noqa: D102
-        return FlatList(
+        l = FlatList(
             (
                 self.binary,
                 self._get_thread_opts(),
-                "-i",
                 self._state.file_helper.tbcs[self._config.tbc_type],
                 "--input-json",
                 self._state.file_helper.tbc_json.file_name,
@@ -40,6 +39,9 @@ class WrapperLDDropoutCorrect(Wrapper):
                 self._config.output_pipes.out_path,
             )
         )
+        if self._state.opts.dropout_allow_interfield is False:
+            l.append("-i")
+        return l
 
     def _get_thread_opts(self) -> FlatList | None:
         thread_count = self._state.opts.threads


### PR DESCRIPTION
Previously tbc-video-decode unconditionally uses the --intra flag with ld-dropout-correct.  This prevents ld-dropout-correct from using data from the other video field as replacement data.  When working with tape media (as opposed to laser disc) it can be very useful to use the other field as replacement data, such as when one head/track consistently has more dropouts than the other.