### PR TITLE
selectively enable interfield dropout

### DIFF
--- a/src/tbc_video_export/opts/opt_types.py
+++ b/src/tbc_video_export/opts/opt_types.py
@@ -6,6 +6,7 @@ from tbc_video_export.common.enums import (
     ChromaDecoder,
     FieldOrder,
     VideoSystem,
+    TBCType,
 )
 
 if TYPE_CHECKING:
@@ -68,6 +69,22 @@ class TypeOverrideAudioProfile:
         # add to config
         self._config.add_additional_filter(value)
         return value
+    
+
+class TypeDropoutInterfieldCorrection:
+    """Return TBCType value if it exists."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        self._parser = parser
+
+    def __call__(self, value: str) -> TBCType:  # noqa: D102
+        try:
+            return TBCType[value.upper()]
+        except KeyError:
+            self._parser.error(
+                f"argument --dropout-interfield-correction: invalid value: '{value}', "
+                f"check --help for available options."
+            )
 
 
 class TypeChromaDecoder:

--- a/src/tbc_video_export/opts/opts.py
+++ b/src/tbc_video_export/opts/opts.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
         HardwareAccelType,
         VideoFormatType,
         VideoSystem,
+        TBCType,
     )
 
 
@@ -76,7 +77,7 @@ class Opts(argparse.Namespace):
     # dropout-correct
     no_dropout_correct: bool
     dropout_correct_threads: int | None
-    dropout_allow_interfield: bool
+    dropout_interfield_correction: TBCType
 
     # luma
     luma_only: bool

--- a/src/tbc_video_export/opts/opts_ldtools.py
+++ b/src/tbc_video_export/opts/opts_ldtools.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 
-from tbc_video_export.common.enums import ChromaDecoder
+from tbc_video_export.common.enums import ChromaDecoder, TBCType
 from tbc_video_export.opts import opt_types
 
 
@@ -313,16 +313,22 @@ def add_ldtool_opts(parent: argparse.ArgumentParser) -> None:
     )
 
     dropout_correct_opts.add_argument(
-        "--dropout-allow-interfield",
-        action="store_true",
-        default=False,
+        "--dropout-interfield-correction",
+        type=opt_types.TypeDropoutInterfieldCorrection(parent),
+        choices=list(TBCType),
+        default=TBCType.NONE,
         help=(
-            "Allow interfield dropout correction. (default: no)\n"
+            "Enable interfield dropout correction.\n"
             "  - This will run ld-dropout-correct without the --intra flag."
+            "\n\n"
+            "Available Options:\n"
+            f"  {TBCType.NONE}     Disable interfield dropout correction. (default)\n"
+            f"  {TBCType.LUMA}     Enabled for LUMA only\n"
+            f"  {TBCType.CHROMA}   Enabled for CHROMA only\n"
+            f"  {TBCType.COMBINED} Enabled for LUMA and CHROMA"
             "\n\n"
         ),
     )
-
 
     # process-vbi
     process_vbi = parent.add_argument_group("process vbi")


### PR DESCRIPTION
* Allow interfield dropout correction to be enabled for luma, chroma, both, or none.
  * Interfield dropout correction doesn't work correctly with NTSC chroma, so this option allows it to be enabled for only the luma tbc.
* rename `--dropout-allow-interfield` to `--dropout-interfield-correction`