### PR TITLE
fix(ffmpeg wrapper): trim audio to match --start/--length frame range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/JuniorIsAJitterbug/tbc-video-export"
 keywords = ["vhs-decode", "ld-decode", "cvbs-decode", "tbc", "rf capture"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.14"
+python = ">=3.10,<3.15"
 pywin32 = [{ version = "^306", platform = "win32", source = "pypi" }]
 typing-extensions = "^4.10.0"
 
@@ -30,6 +30,7 @@ poetry-dynamic-versioning = { extras = ["plugin"], version = "^1.2.0" }
 pytest = "^8.1.1"
 pytest-mock = "^3.14.0"
 pymediainfo = "^6.1.0"
+rapidfuzz = "^3.14.3"
 
 [tool.poetry.group.appimage]
 optional = true

--- a/src/tbc_video_export/__main__.py
+++ b/src/tbc_video_export/__main__.py
@@ -58,6 +58,9 @@ async def _run(argv: list[str]) -> None:
             )
 
             await handler.run()
+
+            if not handler.completed_successfully:
+                sys.exit(1)
     except Exception as e:  # noqa: BLE001
         exceptions.handle_exceptions(e)
     finally:

--- a/src/tbc_video_export/common/video_system.py
+++ b/src/tbc_video_export/common/video_system.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from fractions import Fraction
+from typing import ClassVar, Literal, TypeAlias
 
 from tbc_video_export.common.enums import ChromaDecoder, ExportMode, VideoSystem
 
@@ -71,6 +72,16 @@ class VideoSystemData:
         color_primaries: str
         color_trc: str
         fps: str
+
+        _FPS_RATES: ClassVar[dict[str, Fraction]] = {
+            "pal": Fraction(25),
+            "ntsc": Fraction(30000, 1001),
+        }
+
+        @property
+        def fps_fraction(self) -> Fraction:
+            """Return fps as a Fraction for precise frame-to-time arithmetic."""
+            return self._FPS_RATES[self.fps]
 
 
 video_system_pal = VideoSystemData(

--- a/src/tbc_video_export/common/video_system.py
+++ b/src/tbc_video_export/common/video_system.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import ClassVar, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 from tbc_video_export.common.enums import ChromaDecoder, ExportMode, VideoSystem
 
@@ -25,6 +25,7 @@ class VideoSystemData:
     aspect_ratio: dict[VideoAspectRatioType, AspectRatio]
     chroma_decoder: dict[ExportMode, ChromaDecoder]
     ffmpeg_config: FFmpegConfig
+    fps_fraction: Fraction
 
     @staticmethod
     def get(system: VideoSystem) -> VideoSystemData:
@@ -73,16 +74,6 @@ class VideoSystemData:
         color_trc: str
         fps: str
 
-        _FPS_RATES: ClassVar[dict[str, Fraction]] = {
-            "pal": Fraction(25),
-            "ntsc": Fraction(30000, 1001),
-        }
-
-        @property
-        def fps_fraction(self) -> Fraction:
-            """Return fps as a Fraction for precise frame-to-time arithmetic."""
-            return self._FPS_RATES[self.fps]
-
 
 video_system_pal = VideoSystemData(
     size={
@@ -113,6 +104,7 @@ video_system_pal = VideoSystemData(
         "bt709",
         "pal",
     ),
+    fps_fraction=Fraction(25),
 )
 
 video_system_ntsc = VideoSystemData(
@@ -144,6 +136,7 @@ video_system_ntsc = VideoSystemData(
         "bt709",
         "ntsc",
     ),
+    fps_fraction=Fraction(30000, 1001),
 )
 
 video_system_palm = VideoSystemData(
@@ -175,6 +168,7 @@ video_system_palm = VideoSystemData(
         "bt709",
         "ntsc",
     ),
+    fps_fraction=Fraction(30000, 1001),
 )
 
 VideoSizeType: TypeAlias = Literal["default", "4fsc"]

--- a/src/tbc_video_export/process/process_handler.py
+++ b/src/tbc_video_export/process/process_handler.py
@@ -39,6 +39,15 @@ class ProcessHandler:
         self._user_cancellation_event = asyncio.Event()
         self._proc_error_event = asyncio.Event()
 
+    @property
+    def completed_successfully(self) -> bool:
+        """Return True if the handler has run and all processes finished without error."""
+        return (
+            self._has_run
+            and not self._proc_error_event.is_set()
+            and not self._user_cancellation_event.is_set()
+        )
+
     async def run(self) -> None:
         """Start the procs."""
         self._create_wrapper_groups()

--- a/src/tbc_video_export/process/wrapper/wrapper_ffmpeg.py
+++ b/src/tbc_video_export/process/wrapper/wrapper_ffmpeg.py
@@ -200,7 +200,7 @@ class WrapperFFmpeg(Wrapper):
         if self._state.opts.start is None and self._state.opts.length is None:
             return None, None
 
-        fps = self._state.video_system_data.ffmpeg_config.fps_fraction
+        fps = self._state.video_system_data.fps_fraction
         start_frame = self._state.opts.start or 0
 
         ss = f"{float(Fraction(start_frame) / fps):.6f}" if start_frame > 0 else None

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -33,7 +33,7 @@ class TestOutput:
             "format": "FFV1",
             "format_settings__gop": "N=1",
             "coder_type": "Range Coder",
-            "maxslicescount": "24",
+            "maxslicescount": "4",
             "errordetectiontype": "Per slice",
         },
         "prores_hq": {
@@ -119,7 +119,7 @@ class TestOutput:
         "format": "FFV1",
         "format_settings__gop": "N=1",
         "coder_type": "Range Coder",
-        "maxslicescount": "24",
+        "maxslicescount": "4",
         "errordetectiontype": "Per slice",
     }
 


### PR DESCRIPTION
When using `--start`, `--length`, and `--audio-track`, the video was trimmed by the decoder but audio was muxed in full. Added input-level `-ss` and `-t` flags to audio inputs so they match the trimmed video bounds.